### PR TITLE
Development environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,9 +6,9 @@ This is a pnpm monorepo containing two blog websites under `websites/`. All scri
 
 ### Services
 
-| Service | Dev command | Port | Notes |
-|---|---|---|---|
-| Astro blog | `pnpm dev:astro` | 4321 | Primary blog site |
+| Service       | Dev command         | Port | Notes                                                            |
+| ------------- | ------------------- | ---- | ---------------------------------------------------------------- |
+| Astro blog    | `pnpm dev:astro`    | 4321 | Primary blog site                                                |
 | TanStack blog | `pnpm dev:tanstack` | 3000 | Secondary blog; serves at `/` in dev, `/tanstack/` in production |
 
 ### Key commands

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,26 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a pnpm monorepo containing two blog websites under `websites/`. All scripts are defined in the root `package.json`.
+
+### Services
+
+| Service | Dev command | Port | Notes |
+|---|---|---|---|
+| Astro blog | `pnpm dev:astro` | 4321 | Primary blog site |
+| TanStack blog | `pnpm dev:tanstack` | 3000 | Secondary blog; serves at `/` in dev, `/tanstack/` in production |
+
+### Key commands
+
+See root `package.json` `scripts` for the full list. Highlights:
+
+- **Lint**: `pnpm run lint:check` (oxlint), `pnpm run format:check` (Prettier)
+- **Build**: `pnpm run build:astro`, `pnpm run build:tanstack`
+- **Type check**: `pnpm run tsc:check` (tsgo preview — has known pre-existing errors, not run in CI)
+
+### Gotchas
+
+- **pnpm 10 build scripts**: The repo originally targeted pnpm 9 (see CI). Under pnpm 10 the `pnpm.onlyBuiltDependencies` field in root `package.json` is required to allow native package builds (`esbuild`, `sharp`, `@tailwindcss/oxide`, `@parcel/watcher`). If this field is missing, `pnpm install` will skip build scripts and Tailwind/Sharp/esbuild will not work.
+- **Content sync**: Both websites auto-run a sync script (`pnpm sync`) as part of their `dev`/`build` scripts. This copies markdown from root `_posts/`/`_notes/`/`_info/` into each website's `src/content/`. No manual sync step is needed.
+- **Playwright**: The Astro build invokes Playwright for Mermaid diagram rendering (`rehype-mermaid`). Run `pnpm exec playwright install chromium --with-deps` after a fresh `pnpm install` if Chromium is not cached.

--- a/package.json
+++ b/package.json
@@ -39,5 +39,13 @@
     "tsx": "4.20.6",
     "typescript": "5.9.3"
   },
-  "type": "module"
+  "type": "module",
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@parcel/watcher",
+      "@tailwindcss/oxide",
+      "esbuild",
+      "sharp"
+    ]
+  }
 }


### PR DESCRIPTION
Configure pnpm for native builds and add `AGENTS.md` to document the development environment.

The `pnpm.onlyBuiltDependencies` setting was added to `package.json` to ensure compatibility with pnpm v10, which by default blocks native builds required by packages like `esbuild`, `sharp`, `@tailwindcss/oxide`, and `@parcel/watcher`. This change allows the project to build and run correctly with the current pnpm version.

---
<p><a href="https://cursor.com/agents/bc-96b65ea6-73e8-48e0-a8f7-ee4179910bb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96b65ea6-73e8-48e0-a8f7-ee4179910bb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

