### PR TITLE
Oxlint type aware config

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from "oxlint";
 
 export default defineConfig({
+  options: {
+    typeAware: true,
+  },
   env: {
     browser: true,
     node: true,

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "knip": "5.86.0",
     "oxfmt": "0.36.0",
     "oxlint": "1.51.0",
+    "oxlint-tsgolint": "^0.16.0",
     "tsx": "4.21.0",
     "typescript": "5.9.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,7 +37,10 @@ importers:
         version: 0.36.0
       oxlint:
         specifier: 1.51.0
-        version: 1.51.0
+        version: 1.51.0(oxlint-tsgolint@0.16.0)
+      oxlint-tsgolint:
+        specifier: ^0.16.0
+        version: 0.16.0
       tsx:
         specifier: 4.21.0
         version: 4.21.0
@@ -1075,6 +1078,36 @@ packages:
   '@oxfmt/binding-win32-x64-msvc@0.36.0':
     resolution: {integrity: sha512-MoyeQ9S36ZTz/4bDhOKJgOBIDROd4dQ5AkT9iezhEaUBxAPdNX9Oq0jD8OSnCj3G4wam/XNxVWKMA52kmzmPtQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxlint-tsgolint/darwin-arm64@0.16.0':
+    resolution: {integrity: sha512-WQt5lGwRPJBw7q2KNR0mSPDAaMmZmVvDlEEti96xLO7ONhyomQc6fBZxxwZ4qTFedjJnrHX94sFelZ4OKzS7UQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint-tsgolint/darwin-x64@0.16.0':
+    resolution: {integrity: sha512-VJo29XOzdkalvCTiE2v6FU3qZlgHaM8x8hUEVJGPU2i5W+FlocPpmn00+Ld2n7Q0pqIjyD5EyvZ5UmoIEJMfqg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint-tsgolint/linux-arm64@0.16.0':
+    resolution: {integrity: sha512-MPfqRt1+XRHv9oHomcBMQ3KpTE+CSkZz14wUxDQoqTNdUlV0HWdzwIE9q65I3D9YyxEnqpM7j4qtDQ3apqVvbQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxlint-tsgolint/linux-x64@0.16.0':
+    resolution: {integrity: sha512-XQSwVUsnwLokMhe1TD6IjgvW5WMTPzOGGkdFDtXWQmlN2YeTw94s/NN0KgDrn2agM1WIgAenEkvnm0u7NgwEyw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxlint-tsgolint/win32-arm64@0.16.0':
+    resolution: {integrity: sha512-EWdlspQiiFGsP2AiCYdhg5dTYyAlj6y1nRyNI2dQWq4Q/LITFHiSRVPe+7m7K7lcsZCEz2icN/bCeSkZaORqIg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxlint-tsgolint/win32-x64@0.16.0':
+    resolution: {integrity: sha512-1ufk8cgktXJuJZHKF63zCHAkaLMwZrEXnZ89H2y6NO85PtOXqu4zbdNl0VBpPP3fCUuUBu9RvNqMFiv0VsbXWA==}
     cpu: [x64]
     os: [win32]
 
@@ -3927,6 +3960,10 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  oxlint-tsgolint@0.16.0:
+    resolution: {integrity: sha512-4RuJK2jP08XwqtUu+5yhCbxEauCm6tv2MFHKEMsjbosK2+vy5us82oI3VLuHwbNyZG7ekZA26U2LLHnGR4frIA==}
+    hasBin: true
+
   oxlint@1.51.0:
     resolution: {integrity: sha512-g6DNPaV9/WI9MoX2XllafxQuxwY1TV++j7hP8fTJByVBuCoVtm3dy9f/2vtH/HU40JztcgWF4G7ua+gkainklQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -6114,6 +6151,24 @@ snapshots:
     optional: true
 
   '@oxfmt/binding-win32-x64-msvc@0.36.0':
+    optional: true
+
+  '@oxlint-tsgolint/darwin-arm64@0.16.0':
+    optional: true
+
+  '@oxlint-tsgolint/darwin-x64@0.16.0':
+    optional: true
+
+  '@oxlint-tsgolint/linux-arm64@0.16.0':
+    optional: true
+
+  '@oxlint-tsgolint/linux-x64@0.16.0':
+    optional: true
+
+  '@oxlint-tsgolint/win32-arm64@0.16.0':
+    optional: true
+
+  '@oxlint-tsgolint/win32-x64@0.16.0':
     optional: true
 
   '@oxlint/binding-android-arm-eabi@1.51.0':
@@ -9190,7 +9245,16 @@ snapshots:
       '@oxfmt/binding-win32-ia32-msvc': 0.36.0
       '@oxfmt/binding-win32-x64-msvc': 0.36.0
 
-  oxlint@1.51.0:
+  oxlint-tsgolint@0.16.0:
+    optionalDependencies:
+      '@oxlint-tsgolint/darwin-arm64': 0.16.0
+      '@oxlint-tsgolint/darwin-x64': 0.16.0
+      '@oxlint-tsgolint/linux-arm64': 0.16.0
+      '@oxlint-tsgolint/linux-x64': 0.16.0
+      '@oxlint-tsgolint/win32-arm64': 0.16.0
+      '@oxlint-tsgolint/win32-x64': 0.16.0
+
+  oxlint@1.51.0(oxlint-tsgolint@0.16.0):
     optionalDependencies:
       '@oxlint/binding-android-arm-eabi': 1.51.0
       '@oxlint/binding-android-arm64': 1.51.0
@@ -9211,6 +9275,7 @@ snapshots:
       '@oxlint/binding-win32-arm64-msvc': 1.51.0
       '@oxlint/binding-win32-ia32-msvc': 1.51.0
       '@oxlint/binding-win32-x64-msvc': 1.51.0
+      oxlint-tsgolint: 0.16.0
 
   p-limit@2.3.0:
     dependencies:

--- a/websites/tanstack/src/components/search/Search.tsx
+++ b/websites/tanstack/src/components/search/Search.tsx
@@ -40,7 +40,7 @@ export function Search({ items, onResultClick, autoFocus = false }: SearchProps)
 
   useEffect(() => {
     let cancelled = false;
-    (async () => {
+    void (async () => {
       const database = await create({
         schema,
       });
@@ -75,7 +75,7 @@ export function Search({ items, onResultClick, autoFocus = false }: SearchProps)
   );
 
   useEffect(() => {
-    runSearch(query);
+    void runSearch(query);
   }, [query, runSearch]);
 
   return (

--- a/websites/tanstack/src/routes/blog/$postId.tsx
+++ b/websites/tanstack/src/routes/blog/$postId.tsx
@@ -3,6 +3,7 @@ import { Link } from "@tanstack/react-router";
 import { allPosts } from "content-collections";
 import Markdown from "markdown-to-jsx";
 import { format } from "date-fns";
+import { isValidElement } from "react";
 import { BlogLayout } from "../../components/blog/BlogLayout";
 import { CodeBlock } from "../../components/blog/CodeBlock";
 import { Giscus } from "../../components/Giscus";
@@ -29,6 +30,16 @@ function resolveBlogImageSrc(src: string | undefined, postSlug: string): string 
 
   const normalizedSrc = src.replace(/^\.\//, "");
   return `/content/blog/${postSlug}/${normalizedSrc}`;
+}
+
+function getTextContent(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "bigint") return value.toString();
+  if (Array.isArray(value)) return value.map((item) => getTextContent(item)).join("");
+  if (isValidElement<{ children?: unknown }>(value)) {
+    return getTextContent(value.props.children);
+  }
+  return "";
 }
 
 export const Route = createFileRoute("/blog/$postId")({
@@ -78,11 +89,6 @@ function RouteComponent() {
   const getLanguage = (className?: string) => {
     const langMatch = (className ?? "").match(/language-([\w-]+)/);
     return langMatch ? langMatch[1] : "typescript";
-  };
-
-  const getCodeText = (children: unknown) => {
-    if (typeof children === "string") return children;
-    return String(children ?? "");
   };
 
   return (
@@ -173,7 +179,7 @@ function RouteComponent() {
                 overrides: {
                   h2: {
                     component: ({ children, ...props }) => {
-                      const text = typeof children === "string" ? children : String(children);
+                      const text = getTextContent(children);
                       const id = text
                         .toLowerCase()
                         .replace(/[^a-z0-9]+/g, "-")
@@ -187,7 +193,7 @@ function RouteComponent() {
                   },
                   h3: {
                     component: ({ children, ...props }) => {
-                      const text = typeof children === "string" ? children : String(children);
+                      const text = getTextContent(children);
                       const id = text
                         .toLowerCase()
                         .replace(/[^a-z0-9]+/g, "-")
@@ -209,12 +215,12 @@ function RouteComponent() {
                           }
                         ).props;
                         const language = getLanguage(codeProps?.className);
-                        const code = getCodeText(codeProps?.children);
+                        const code = getTextContent(codeProps?.children);
                         return <CodeBlock code={code} language={language} />;
                       }
                       const preProps = props as { className?: string };
                       const language = getLanguage(preProps.className);
-                      const code = getCodeText(children);
+                      const code = getTextContent(children);
                       return <CodeBlock code={code} language={language} />;
                     },
                   },
@@ -222,7 +228,7 @@ function RouteComponent() {
                     component: ({ children, className, ...props }) => {
                       if (className?.includes("language-")) {
                         const language = getLanguage(className);
-                        const code = getCodeText(children);
+                        const code = getTextContent(children);
                         return <CodeBlock code={code} language={language} />;
                       }
 

--- a/websites/tanstack/src/routes/notes/$noteId.tsx
+++ b/websites/tanstack/src/routes/notes/$noteId.tsx
@@ -2,9 +2,20 @@ import { createFileRoute, Link, notFound } from "@tanstack/react-router";
 import { allNotes } from "content-collections";
 import Markdown from "markdown-to-jsx";
 import { format } from "date-fns";
+import { isValidElement } from "react";
 import { BlogLayout } from "../../components/blog/BlogLayout";
 import { CodeBlock } from "../../components/blog/CodeBlock";
 import { createRouteHead, generateSEOTags } from "../../lib/seo";
+
+function getTextContent(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "bigint") return value.toString();
+  if (Array.isArray(value)) return value.map((item) => getTextContent(item)).join("");
+  if (isValidElement<{ children?: unknown }>(value)) {
+    return getTextContent(value.props.children);
+  }
+  return "";
+}
 
 export const Route = createFileRoute("/notes/$noteId")({
   head: ({ params }) => {
@@ -57,11 +68,6 @@ function NoteDetailPage() {
   const getLanguage = (className?: string) => {
     const langMatch = (className ?? "").match(/language-([\w-]+)/);
     return langMatch ? langMatch[1] : "typescript";
-  };
-
-  const getCodeText = (children: unknown) => {
-    if (typeof children === "string") return children;
-    return String(children ?? "");
   };
 
   return (
@@ -117,12 +123,12 @@ function NoteDetailPage() {
                         }
                       ).props;
                       const language = getLanguage(codeProps?.className);
-                      const code = getCodeText(codeProps?.children);
+                      const code = getTextContent(codeProps?.children);
                       return <CodeBlock code={code} language={language} />;
                     }
                     const preProps = props as { className?: string };
                     const language = getLanguage(preProps.className);
-                    const code = getCodeText(children);
+                    const code = getTextContent(children);
                     return <CodeBlock code={code} language={language} />;
                   },
                 },
@@ -131,7 +137,7 @@ function NoteDetailPage() {
                   component: ({ children, className, ...props }) => {
                     if (className?.includes("language-")) {
                       const language = getLanguage(className);
-                      const code = getCodeText(children);
+                      const code = getTextContent(children);
                       return <CodeBlock code={code} language={language} />;
                     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Enable oxlint type-aware linting and resolve newly surfaced warnings.

This PR adds the `oxlint-tsgolint` dependency and activates type-aware mode in the oxlint configuration. It also includes fixes for four warnings that became apparent after enabling this mode, specifically addressing unsafe promise handling and markdown content extraction.

---
<p><a href="https://cursor.com/agents/bc-3f45b074-7df5-47b0-b96f-57f969b48f49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3f45b074-7df5-47b0-b96f-57f969b48f49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->