### PR TITLE
Cover image display

### DIFF
--- a/websites/tanstack/e2e/smoke.spec.ts
+++ b/websites/tanstack/e2e/smoke.spec.ts
@@ -14,8 +14,26 @@ test.describe("tanstack smoke", () => {
       .poll(async () => firstPreviewCard.evaluate((element) => getComputedStyle(element).cursor))
       .toBe("pointer");
 
+    const previewTitle = (await firstPreviewCard.locator("h2").textContent())?.trim();
+
     await firstPreviewCard.click({ position: { x: 32, y: 32 } });
     await expect(page).toHaveURL(/\/blog\/[^/]+$/);
+
+    const headerCoverImage = page.locator("article header img").first();
+    await expect(headerCoverImage).toBeVisible();
+    await expect(headerCoverImage).toHaveAttribute("src", /\/content\/blog\/.+/);
+    await expect
+      .poll(async () =>
+        headerCoverImage.evaluate((image) => image.complete && image.naturalWidth > 0),
+      )
+      .toBe(true);
+
+    if (previewTitle) {
+      await expect(headerCoverImage).toHaveAttribute(
+        "alt",
+        new RegExp(`^Cover image for ${previewTitle.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`),
+      );
+    }
   });
 
   test("blog preview card tags stay clickable", async ({ page }) => {

--- a/websites/tanstack/src/routes/blog/$postId.tsx
+++ b/websites/tanstack/src/routes/blog/$postId.tsx
@@ -153,6 +153,20 @@ function RouteComponent() {
               )}
             </div>
 
+            {post.cover_image && (
+              <figure className="mb-8">
+                <div className="overflow-hidden rounded-2xl border border-gray-200 bg-white/80 p-3 shadow-xl dark:border-gray-600/40 dark:bg-gray-800/70">
+                  <img
+                    src={post.cover_image}
+                    alt={`Cover image for ${post.title}`}
+                    className="mx-auto h-auto max-h-[32rem] w-full rounded-xl object-contain"
+                    loading="eager"
+                    decoding="async"
+                  />
+                </div>
+              </figure>
+            )}
+
             {/* Tags */}
             {post.tags.length > 0 && (
               <div className="flex flex-wrap justify-center gap-2 mb-8">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Display blog post cover images on individual post pages.

Blog posts previously only showed cover images in preview cards, not on the actual post page. This PR fixes that presentation bug and adds a smoke test to verify the cover image is visible on the detail page.

<div><a href="https://cursor.com/agents/bc-24c9022d-04ef-49b2-83fb-6279162050d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-24c9022d-04ef-49b2-83fb-6279162050d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->