### PR TITLE
Notes giscus integration

### DIFF
--- a/websites/tanstack/e2e/smoke.spec.ts
+++ b/websites/tanstack/e2e/smoke.spec.ts
@@ -59,6 +59,18 @@ test.describe("tanstack smoke", () => {
     await expect(page).toHaveURL(/\/$/);
   });
 
+  test("note detail pages render the comments section", async ({ page }) => {
+    await page.goto("/notes");
+
+    const firstNote = page.locator('main article a[href^="/notes/"]').first();
+
+    await expect(firstNote).toBeVisible();
+    await firstNote.click();
+
+    await expect(page).toHaveURL(/\/notes\/[^/]+$/);
+    await expect(page.locator("section.giscus")).toBeVisible();
+  });
+
   test("search modal opens and closes", async ({ page }) => {
     await page.goto("/");
 

--- a/websites/tanstack/src/routes/notes/$noteId.tsx
+++ b/websites/tanstack/src/routes/notes/$noteId.tsx
@@ -5,6 +5,7 @@ import { format } from "date-fns";
 import { isValidElement } from "react";
 import { BlogLayout } from "../../components/blog/BlogLayout";
 import { CodeBlock } from "../../components/blog/CodeBlock";
+import { Giscus } from "../../components/Giscus";
 import { createRouteHead, generateSEOTags } from "../../lib/seo";
 import { siteConfig } from "../../lib/site";
 
@@ -196,6 +197,8 @@ function NoteDetailPage() {
               ))}
             </div>
           )}
+
+          <Giscus category="notes" />
         </footer>
       </article>
     </BlogLayout>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implement Giscus comments on note detail pages to restore previous functionality.

This PR adds the existing `Giscus` component to note detail pages and includes a Playwright smoke test to verify its presence.

<div><a href="https://cursor.com/agents/bc-4e9861bb-0891-44f2-8155-aee8fd65f4ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e9861bb-0891-44f2-8155-aee8fd65f4ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->